### PR TITLE
New versions of the `aws` cli return None instead of null

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -129,10 +129,10 @@ function validate_s3_bucket() {
     return $result
   fi
 
-  local resp=$(aws --profile ${AWS_PROFILE} --region ${TF_VAR_aws_region} s3api get-bucket-location --bucket ${bucket})
+    local resp=$(aws --profile ${AWS_PROFILE} --region ${TF_VAR_aws_region} s3api get-bucket-location --bucket ${bucket})
   # This is a special case for us-east-1. The AWS API returns null for legacy reasons.
   if [ "${TF_VAR_aws_region}" == "us-east-1" ]; then
-    echo $resp | grep None &> /dev/null || {
+    echo $resp | grep 'null\|None' &> /dev/null || {
       echo "Bucket ${bucket} is not in ${TF_VAR_aws_region}"
       return 1
     }

--- a/src/install.sh
+++ b/src/install.sh
@@ -14,7 +14,6 @@ function startup() {
 
 EOF
 
-
   UNINSTALL_ARMORY_SPINNAKER="false"
   set -o pipefail
   BLUE='\033[0;34m'
@@ -129,7 +128,7 @@ function validate_s3_bucket() {
     return $result
   fi
 
-    local resp=$(aws --profile ${AWS_PROFILE} --region ${TF_VAR_aws_region} s3api get-bucket-location --bucket ${bucket})
+  local resp=$(aws --profile ${AWS_PROFILE} --region ${TF_VAR_aws_region} s3api get-bucket-location --bucket ${bucket})
   # This is a special case for us-east-1. The AWS API returns null for legacy reasons.
   if [ "${TF_VAR_aws_region}" == "us-east-1" ]; then
     echo $resp | grep 'null\|None' &> /dev/null || {

--- a/src/install.sh
+++ b/src/install.sh
@@ -14,7 +14,7 @@ function startup() {
 
 EOF
 
-  
+
   UNINSTALL_ARMORY_SPINNAKER="false"
   set -o pipefail
   BLUE='\033[0;34m'
@@ -132,7 +132,7 @@ function validate_s3_bucket() {
   local resp=$(aws --profile ${AWS_PROFILE} --region ${TF_VAR_aws_region} s3api get-bucket-location --bucket ${bucket})
   # This is a special case for us-east-1. The AWS API returns null for legacy reasons.
   if [ "${TF_VAR_aws_region}" == "us-east-1" ]; then
-    echo $resp | grep null &> /dev/null || {
+    echo $resp | grep None &> /dev/null || {
       echo "Bucket ${bucket} is not in ${TF_VAR_aws_region}"
       return 1
     }


### PR DESCRIPTION
# Description of what was changed
In older versions of the aws CLI it would return 
```
{
    "LocationConstraint": null
}
```
whereas the new versions return

`None`