### PR TITLE
fix uninstall env var

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -14,7 +14,7 @@ function startup() {
 
 EOF
 
-  UNINSTALL_ARMORY_SPINNAKER="false"
+  UNINSTALL_ARMORY_SPINNAKER="${UNINSTALL_ARMORY_SPINNAKER:-false}"
   set -o pipefail
   BLUE='\033[0;34m'
   NC='\033[0m' # No Color


### PR DESCRIPTION
# Description of what was changed
the uninstall environment variable always defaults to false. this just uses false if not otherwise set

